### PR TITLE
Update raw_mediainfo.php

### DIFF
--- a/raw_mediainfo.php
+++ b/raw_mediainfo.php
@@ -1,2 +1,3 @@
 <?php
-echo nl2br(shell_exec('mediainfo "'.urldecode(urldecode($_GET['file'])).'"'));
+$file = escapeshellarg($_GET['file']))
+echo nl2br(shell_exec('mediainfo "'.$file.'"'));


### PR DESCRIPTION
escapeshellarg() adds single quotes around a string and quotes/escapes any existing single quotes allowing you to pass a string directly to a shell function and having it be treated as a single safe argument.

http://php.net/manual/en/function.escapeshellarg.php

Warning
The superglobals $_GET and $_REQUEST are already decoded. Using urldecode() on an element in $_GET or $_REQUEST could have unexpected and dangerous results.
http://php.net/manual/en/function.urldecode.php